### PR TITLE
Add MicroPython package.json for MIP installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "urls": [
+    ["bme280_float.py", "github:robert-hh/BME280/bme280_float.py"],
+    ["bme280_int.py", "github:robert-hh/BME280/bme280_int.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
## Summary
- Adds package.json file with the proper format for MicroPython Package Manager (MIP)
- Enables the library to be installed directly using mip install

## Test plan
- Confirm package.json has the correct structure with urls and deps fields
- Verify GitHub URLs point to the correct repository paths

🤖 Generated with [Claude Code](https://claude.ai/code)