### PR TITLE
Update bme280_float.py

### DIFF
--- a/bme280_float.py
+++ b/bme280_float.py
@@ -136,6 +136,7 @@ class BME280:
                              self._l1_barray)
 
         # Wait for conversion to complete
+        time.sleep_ms(5)  # To give it time to register the request, otherwise sometimes it returns the previous values
         for _ in range(BME280_TIMEOUT):
             if self.i2c.readfrom_mem(self.address, BME280_REGISTER_STATUS, 1)[0] & 0x08:
                 time.sleep_ms(10)  # still busy


### PR DESCRIPTION
When using this library with very high sampling rates (e.g. every 15 ms), it will read the same value twice in a row, before actually performing a new measurement. The result is a pattern of incorrect paired values. This simple addition fixes this problem, but shorter delays might work too, I did not test